### PR TITLE
Update token limit to 2048 and setting SMART_LLM_MODEL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,6 +40,7 @@ OPENAI_API_BASE="http://localhost:8080"
 
 ## SMART_LLM_MODEL - Smart language model (Default: gpt-4)
 ## FAST_LLM_MODEL - Fast language model (Default: gpt-3.5-turbo)
+SMART_LLM_MODEL="gpt-3.5-turbo"
 
 ### LLM MODEL SETTINGS
 ## FAST_TOKEN_LIMIT - Fast token limit for OpenAI (Default: 4000), using LocalLLM most have 2048

--- a/.env.template
+++ b/.env.template
@@ -42,10 +42,10 @@ OPENAI_API_BASE="http://localhost:8080"
 ## FAST_LLM_MODEL - Fast language model (Default: gpt-3.5-turbo)
 
 ### LLM MODEL SETTINGS
-## FAST_TOKEN_LIMIT - Fast token limit for OpenAI (Default: 4000)
+## FAST_TOKEN_LIMIT - Fast token limit for OpenAI (Default: 4000), using LocalLLM most have 2048
 ## SMART_TOKEN_LIMIT - Smart token limit for OpenAI (Default: 8000)
 ## When using --gpt3only this needs to be set to 4000.
-# FAST_TOKEN_LIMIT=4000
+ FAST_TOKEN_LIMIT=2048
 # SMART_TOKEN_LIMIT=8000
 
 ### EMBEDDINGS

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AutoGPT4All is a simple bash script that sets up and configures [AutoGPT](https:
 2. Run `./autogtp4all.sh` to start the server.
     - If needed, run `chmod +x autogtp4all.sh` to make the script executable.
 
-> ❗️ Please note this script has been primarily tested on MacOS with an M1 processor. It should work on Linux and Windows, but it has not been thoroughly tested on these platforms.
+> ❗️ Please note this script has been primarily tested on MacOS with an M1 processor. It should work on Linux and Windows, but it has not been thoroughly tested on these platforms. If not on MacOS install git, goland and make before running the script
 
 ## 🎛️ Script Options
 


### PR DESCRIPTION
Most local LLM have a context window/token limit of 2048, including the model downloaded in the script. Additionally I have seen it attempt to use GPT-4 for reasoning which appears to be the same as this issue https://github.com/Significant-Gravitas/Auto-GPT/issues/187. 