### PR TITLE
Include prompt settings and command allowance/deny control

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,10 +13,41 @@
 ## AI_SETTINGS_FILE - Specifies which AI Settings file to use (defaults to ai_settings.yaml)
 # AI_SETTINGS_FILE=ai_settings.yaml
 
+## PROMPT_SETTINGS_FILE - Specifies which Prompt Settings file to use (defaults to prompt_settings.yaml)
+# PROMPT_SETTINGS_FILE=prompt_settings.yaml
+
 ## AUTHORISE COMMAND KEY - Key to authorise commands
 # AUTHORISE_COMMAND_KEY=y
 ## EXIT_KEY - Key to exit AUTO-GPT
 # EXIT_KEY=n
+
+## PLAIN_OUTPUT - Enabeling plain output will disable spinner (Default: False)
+## Note: Spinner is used to indicate that Auto-GPT is working on something in the background
+# PLAIN_OUTPUT=False
+
+## DISABLED_COMMAND_CATEGORIES - The list of categories of commands that are disabled. Each of the below are an option:
+## autogpt.commands.analyze_code
+## autogpt.commands.audio_text
+## autogpt.commands.execute_code
+## autogpt.commands.file_operations
+## autogpt.commands.git_operations
+## autogpt.commands.google_search
+## autogpt.commands.image_gen
+## autogpt.commands.improve_code
+## autogpt.commands.web_selenium
+## autogpt.commands.write_tests
+## autogpt.app
+## autogpt.commands.task_statuses
+## For example, to disable coding related features, uncomment the next line
+# DISABLED_COMMAND_CATEGORIES=autogpt.commands.analyze_code,autogpt.commands.execute_code,autogpt.commands.git_operations,autogpt.commands.improve_code,autogpt.commands.write_tests
+
+## DENY_COMMANDS - The list of commands that are not allowed to be executed by Auto-GPT (Default: None)
+# the following are examples:
+# DENY_COMMANDS=cd,nano,vim,vi,emacs,rm,sudo,top,ping,ssh,scp
+
+## ALLOW_COMMANDS - ONLY those commands will be allowed to be executed by Auto-GPT
+# the following are examples:
+# ALLOW_COMMANDS=ls,git,cat,grep,find,echo,ps,curl,wget
 
 ################################################################################
 ### LLM PROVIDER
@@ -213,7 +244,9 @@ SMART_LLM_MODEL="gpt-3.5-turbo"
 ################################################################################
 
 #ALLOWLISTED_PLUGINS - Sets the listed plugins that are allowed (Example: plugin1,plugin2,plugin3)
+#DENYLISTED_PLUGINS - Sets the listed plugins that are not allowed (Example: plugin1,plugin2,plugin3)
 ALLOWLISTED_PLUGINS=
+DENYLISTED_PLUGINS=
 
 ################################################################################
 ### CHAT PLUGIN SETTINGS


### PR DESCRIPTION
As the official Auto-GPT supports the control over what commands the agent could use and extra prompt settings. I thought it would be a good idea to add those options to the .env.template. This way it stays up to date with the last Auto-GPT changes.